### PR TITLE
Custom Cluster Service Names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# IntelliJ files
+*.iml
+.idea/

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -11,4 +11,4 @@ RUN apt-get update && \
 COPY ./run.sh /usr/bin/run.sh
 RUN chmod u+x /usr/bin/run.sh
 
-ENTRYPOINT "/usr/bin/run.sh"
+ENTRYPOINT ["/usr/bin/run.sh"]

--- a/image/run.sh
+++ b/image/run.sh
@@ -23,8 +23,8 @@ if [[ -n "${KUBERNETES_SERVICE_HOST}" ]]; then
   POD_NAMESPACE=${POD_NAMESPACE:-default}
   MYHOST=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
   echo My host: ${MYHOST}
-
-  URL="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${POD_NAMESPACE}/endpoints/rethinkdb-cluster"
+  RETHINK_CLUSTER=${RETHINK_CLUSTER:-"rethinkdb-cluster"}
+  URL="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/${POD_NAMESPACE}/endpoints/${RETHINK_CLUSTER}"
   echo "Endpont url: ${URL}"
   echo "Looking for IPs..."
   token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)

--- a/rethinkdb-admin.rc.yml
+++ b/rethinkdb-admin.rc.yml
@@ -26,6 +26,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: RETHINK_CLUSTER
+          value: rethinkdb-cluster
         ports:
         - containerPort: 8080
           name: admin-port

--- a/rethinkdb-proxy.rc.yml
+++ b/rethinkdb-proxy.rc.yml
@@ -26,6 +26,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: RETHINK_CLUSTER
+          value: rethinkdb-cluster
         ports:
         - containerPort: 8080
           name: admin-port

--- a/rethinkdb-replica.rc.1.yml
+++ b/rethinkdb-replica.rc.1.yml
@@ -30,6 +30,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: RETHINK_CLUSTER
+          value: rethinkdb-cluster
         ports:
         - containerPort: 8080
           name: admin-port

--- a/rethinkdb-replica.rc.2.yml
+++ b/rethinkdb-replica.rc.2.yml
@@ -30,6 +30,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: RETHINK_CLUSTER
+          value: rethinkdb-cluster
         ports:
         - containerPort: 8080
           name: admin-port

--- a/rethinkdb-replica.rc.3.yml
+++ b/rethinkdb-replica.rc.3.yml
@@ -30,6 +30,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: RETHINK_CLUSTER
+          value: rethinkdb-cluster
         ports:
         - containerPort: 8080
           name: admin-port

--- a/rethinkdb-replica.rc.yml
+++ b/rethinkdb-replica.rc.yml
@@ -24,6 +24,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: RETHINK_CLUSTER
+          value: rethinkdb-cluster
         ports:
         - containerPort: 8080
           name: admin-port


### PR DESCRIPTION
Adding an environment variable option which sets the name of the master cluster service.

This lets the same Docker image be used with multiple services (ex: a test cluster and a production cluster)
